### PR TITLE
ChainID opcode Integration tests

### DIFF
--- a/contracts/ChainID.sol
+++ b/contracts/ChainID.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.5.15;
+
+contract ChainID {
+
+	function getChainId() external view returns (uint8) {
+	    uint8 myid;
+	    assembly {
+	        myid := chainid()
+	    }
+	    return myid;
+	}
+}

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,6 +1,7 @@
 const Migrations = artifacts.require("Migrations");
 const Create2 = artifacts.require("Create2");
 const Recursive = artifacts.require("Recursive");
+const ChainID = artifacts.require("ChainID");
 
 const Sample = artifacts.require("Sample");
 
@@ -9,6 +10,5 @@ module.exports = function(deployer) {
   deployer.deploy(Create2);
   deployer.deploy(Recursive);
   deployer.deploy(Sample);
-
-
+  deployer.deploy(ChainID);
 };

--- a/test/basic-tests/TestChainID.js
+++ b/test/basic-tests/TestChainID.js
@@ -1,0 +1,17 @@
+const ChainID = artifacts.require("ChainID");
+var assert = require('assert');
+
+contract('ChainID', async () => {
+  it('Should return correct chain ID', async () => {
+    //deploys chainID contract 
+    const chainIdContract = await ChainID.deployed();
+    
+    //get chainID by opcode
+    let actual = await chainIdContract.getChainId.call();
+
+    //get chainID by web3 method
+    let expected  = await web3.eth.net.getId();
+    
+    assert.equal(actual, expected);
+  });
+});

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -90,14 +90,14 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      // version: "0.5.1",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.5.15",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {
       //    enabled: false,
       //    runs: 200
       //  },
-      //  evmVersion: "byzantium"
+        evmVersion: "istanbul"
       // }
     }
   }


### PR DESCRIPTION
PR for the integration test for the new opcode introduced in the upcoming release.

It includes a necessary update of the solc version for the test to pass and the evmVersion for the same reason.

All old tests pass with the new config