### PR TITLE
Upgrade docker image and simplify cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-                - node-v1-{{ .Branch }}-{{ checksum "package-lock.json" }}
+                - node-v1-{{ checksum "package-lock.json" }}
               
       - run:
           name: Prepare Truffle
@@ -53,7 +53,7 @@ jobs:
       - save_cache:
           paths:
                 - ~/tmp/node_modules 
-          key: node-v1-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          key: node-v1-{{ checksum "package-lock.json" }}
 
       - run:
           name: Start RskJ & Run Truffle Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
     working_directory: ~/smart-contracts
     # The primary container is an instance of the first image listed. The job's commands run in this container.
     docker:
-      - image: cimg/openjdk:8.0-node
+      - image: cimg/openjdk:8.0.292-node
 
     steps:
       - checkout


### PR DESCRIPTION
Moving from image: cimg/openjdk:8.0-node to image: cimg/openjdk:8.0.292-node for better support and performance.
Simplifying cache name for better reusage.