### PR TITLE
daily default test plan update

### DIFF
--- a/xray-conf/createTestExecution.json
+++ b/xray-conf/createTestExecution.json
@@ -16,6 +16,6 @@
         ] 
     },
     "xrayFields": {
-        "testPlanKey": "CORE-3588"
+        "testPlanKey": "CORE-941"
     }
 }


### PR DESCRIPTION
The current link test plan doesn't exist, it's actually a test execution so new daily runs are not being uploaded to Jira.
<img width="1387" alt="image" src="https://github.com/rsksmart/rskj-truffle-tests/assets/106695271/6028192e-a15c-4273-a5d1-e7de44b12ea5">

Linking the default test plan for daily executions:
https://rsklabs.atlassian.net/browse/CORE-941